### PR TITLE
feat: add Codex subscription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![デモ: テキストからモーション生成](video/demo.gif)
 
-テキストを入力すると、OpenAI API がキーフレームを設計し、
+テキストを入力すると、OpenAI API または Codex サブスクリプションがキーフレームを設計し、
 **VRMA (VRM Animation / `.vrma`)** ファイルをブラウザ内で生成して、
 その場で VRM キャラクターを動かす Web アプリです。
 生成した `.vrma` はファイルとして保存でき、VRMA 対応アプリでそのまま利用できます。
@@ -15,7 +15,12 @@
 ## 必要なもの
 
 - Node.js 20+
-- OpenAI API キー ([platform.openai.com](https://platform.openai.com/) で取得)
+- 次のいずれか
+  - OpenAI API キー ([platform.openai.com](https://platform.openai.com/) で取得)
+  - デスクトップ版では、PATH 上の Codex CLI 0.144.1 以上と利用可能なChatGPT/Codexプラン
+
+Codexサブスクリプション認証はElectronデスクトップ版専用です。ブラウザ版ではAPIキーを使用してください。
+Codex CLIはアプリに同梱されないため、別途インストールが必要です。
 
 VRM モデルは [VRoid 公式サンプルモデル (AvatarSample)](https://hub.vroid.com/characters/2843975675147313744/models/5644550979324015604)
 の VRM1.0 版・VRM0.0 版を同梱しており、起動時に VRM1.0 版が読み込まれます。
@@ -37,8 +42,12 @@ npm run dev
 
 1. 起動するとサンプルモデル (AvatarSample VRM1.0版) が読み込まれます。
    「VRMファイルを開く」または 3D ビューへのドラッグ&ドロップで手持ちの VRM に差し替え可能
-2. OpenAI API キーを入力し、モデル (gpt-5.6 系) を選択
-   - キーはブラウザの localStorage にのみ保存され、OpenAI 以外には送信されません
+2. 認証方式とモデルを選択
+   - **OpenAI APIキー**: キーを入力し、API用モデルを選択します。キーはブラウザの
+     localStorage にのみ保存され、OpenAI 以外には送信されません
+   - **Codexサブスクリプション（デスクトップ版）**: 「ChatGPTでログイン」を押して
+     既定ブラウザで認証します。既にCodex CLIでログイン済みなら、その認証を再利用します
+   - CodexのトークンはCodex CLIが管理し、アプリのレンダラーやlocalStorageには保存されません
 3. テキストを入力して「▶ モーション生成 & 再生」 (Ctrl+Enter でも可)
    - 「🔍 自己修正」ON (デフォルト) では生成後にもう1パス、可動域・軌道・緩急の
      セルフレビューを行い品質を上げます (API呼び出しが2回になります)
@@ -47,7 +56,7 @@ npm run dev
 ## アーキテクチャ
 
 ```text
-テキスト ── OpenAI API ──▶ モーション spec (ボーン別オイラー角キーフレーム JSON)
+テキスト ── OpenAI API / Codex CLI ──▶ モーション spec (ボーン別オイラー角キーフレーム JSON)
                                    │
                                    ▼
               vrmaBuilder.js ── glTF + VRMC_vrm_animation 拡張 → GLB (.vrma)
@@ -63,6 +72,8 @@ npm run dev
 | `src/viewer.js` | three.js シーン / VRM ロード / VRMA 再生 |
 | `src/idleMotion.js` | 待機モーション (呼吸) |
 | `src/main.js` | UI 結線 |
+| `electron/codex-client.cjs` | Codex app-server接続 / ChatGPT認証 / モデル取得 / 一時スレッドでの生成 |
+| `electron/preload.cjs` | 認証情報を公開しない限定IPCブリッジ |
 
 ## モーション spec フォーマット
 
@@ -93,12 +104,14 @@ LLM が生成する中間表現です:
 
 - **動作確認環境: Windows 11** (macOS / Linux では動作未確認です。
   ブラウザで動く Web アプリのため動作する見込みはありますが、保証はありません)
-- モーション生成には OpenAI API の利用料が発生します (1回あたり数円〜十数円程度。
+- APIキーモードのモーション生成には OpenAI API の利用料が発生します (1回あたり数円〜十数円程度。
   使用モデルとモーションの長さによって変動)
 - OpenAI の [データ共有プログラム (Complimentary daily tokens)](https://help.openai.com/en/articles/10306912-sharing-feedback-evaluation-and-fine-tuning-data-and-api-inputs-and-outputs-with-openai)
   を有効にすると、1日あたりの無料トークン枠内で**無料で試せます**
   (API の入出力が OpenAI のモデル学習に共有される点に注意。対象アカウント・地域の条件あり。
   本プログラムは OpenAI 側の都合で変更・終了される可能性があります)
+- Codexモードはログイン中のChatGPT/Codexプランの利用上限と組織ポリシーに従います
+- アプリ内のCodexログアウトは、このPC上のCodex CLI全体のログイン状態へ影響します
 - 生成される `.vrma` の利用は各自の責任で行ってください
 - **免責事項**: 本ツールは現状のまま・無保証で提供されます。本ツールの利用
   または利用不能により生じたいかなる損害 (API 利用料、データの損失、

--- a/electron/codex-client.cjs
+++ b/electron/codex-client.cjs
@@ -1,0 +1,421 @@
+const { EventEmitter } = require('node:events');
+const { execFile, spawn } = require('node:child_process');
+const readline = require('node:readline');
+
+const MIN_CODEX_VERSION = [0, 144, 1];
+const REQUEST_TIMEOUT_MS = 30_000;
+const TURN_TIMEOUT_MS = 180_000;
+
+// OpenAI Structured Outputs では object のキーを動的に定義できず、すべての
+// properties を required に含める必要がある。VRM のキー一覧を固定して、
+// 使わないトラックは空配列として返させる。
+const MOTION_BONE_NAMES = [
+  'hips', 'spine', 'chest', 'upperChest', 'neck', 'head',
+  'leftShoulder', 'leftUpperArm', 'leftLowerArm', 'leftHand',
+  'rightShoulder', 'rightUpperArm', 'rightLowerArm', 'rightHand',
+  'leftUpperLeg', 'leftLowerLeg', 'leftFoot',
+  'rightUpperLeg', 'rightLowerLeg', 'rightFoot',
+];
+const MOTION_EXPRESSION_NAMES = [
+  'happy', 'angry', 'sad', 'relaxed', 'surprised', 'neutral',
+  'aa', 'ih', 'ou', 'ee', 'oh',
+  'blink', 'blinkLeft', 'blinkRight',
+  'lookUp', 'lookDown', 'lookLeft', 'lookRight',
+];
+
+const rotationTrackSchema = () => ({
+  type: 'array',
+  items: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['t', 'r'],
+    properties: {
+      t: { type: 'number', minimum: 0, maximum: 20 },
+      r: {
+        type: 'array',
+        minItems: 3,
+        maxItems: 3,
+        items: { type: 'number' },
+      },
+    },
+  },
+});
+
+const expressionTrackSchema = () => ({
+  type: 'array',
+  items: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['t', 'w'],
+    properties: {
+      t: { type: 'number', minimum: 0, maximum: 20 },
+      w: { type: 'number', minimum: 0, maximum: 1 },
+    },
+  },
+});
+
+const MOTION_OUTPUT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['name', 'duration', 'loop', 'tracks', 'hips', 'expressions'],
+  properties: {
+    name: { type: 'string' },
+    duration: { type: 'number', exclusiveMinimum: 0, maximum: 20 },
+    loop: { type: 'boolean' },
+    tracks: {
+      type: 'object',
+      additionalProperties: false,
+      required: MOTION_BONE_NAMES,
+      properties: Object.fromEntries(
+        MOTION_BONE_NAMES.map((name) => [name, rotationTrackSchema()])
+      ),
+    },
+    hips: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['t', 'p'],
+        properties: {
+          t: { type: 'number', minimum: 0, maximum: 20 },
+          p: {
+            type: 'array',
+            minItems: 3,
+            maxItems: 3,
+            items: { type: 'number' },
+          },
+        },
+      },
+    },
+    expressions: {
+      type: 'object',
+      additionalProperties: false,
+      required: MOTION_EXPRESSION_NAMES,
+      properties: Object.fromEntries(
+        MOTION_EXPRESSION_NAMES.map((name) => [name, expressionTrackSchema()])
+      ),
+    },
+  },
+};
+
+function compareVersions(version, minimum = MIN_CODEX_VERSION) {
+  const parts = version.split('.').map((value) => Number.parseInt(value, 10));
+  for (let index = 0; index < minimum.length; index += 1) {
+    const difference = (parts[index] || 0) - minimum[index];
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+function friendlyError(error) {
+  const message = error?.message || String(error);
+  if (error?.code === 'ENOENT' || /not recognized|not found|見つかりません/i.test(message)) {
+    return new Error('Codex CLI が見つかりません。Codex CLI をインストールし、PATH を設定してください。');
+  }
+  if (/usage.?limit|rate.?limit|quota|sessionBudgetExceeded/i.test(message)) {
+    return new Error('Codex の利用上限に達しました。時間をおいてから再試行してください。');
+  }
+  if (/unauthorized|401|authentication required/i.test(message)) {
+    return new Error('Codex の認証が必要です。「ChatGPTでログイン」から認証してください。');
+  }
+  return error instanceof Error ? error : new Error(message);
+}
+
+class CodexClient extends EventEmitter {
+  constructor({ command = 'codex', cwd, spawnProcess = spawn, exec = execFile } = {}) {
+    super();
+    this.command = command;
+    this.cwd = cwd;
+    this.spawnProcess = spawnProcess;
+    this.exec = exec;
+    this.process = null;
+    this.starting = null;
+    this.requestId = 0;
+    this.pending = new Map();
+    this.turns = new Map();
+    this.stderr = '';
+    this.version = null;
+  }
+
+  async getStatus() {
+    try {
+      await this.ensureServer();
+      const result = await this.request('account/read', { refreshToken: false });
+      return {
+        available: true,
+        version: this.version,
+        account: result.account,
+        requiresOpenaiAuth: result.requiresOpenaiAuth,
+      };
+    } catch (error) {
+      const friendly = friendlyError(error);
+      return { available: false, version: this.version, account: null, error: friendly.message };
+    }
+  }
+
+  async login() {
+    await this.ensureServer();
+    return this.request('account/login/start', {
+      type: 'chatgpt',
+      appBrand: 'codex',
+      codexStreamlinedLogin: true,
+      useHostedLoginSuccessPage: true,
+    });
+  }
+
+  async logout() {
+    await this.ensureServer();
+    await this.request('account/logout', {});
+    return this.getStatus();
+  }
+
+  async listModels() {
+    await this.ensureServer();
+    const models = [];
+    let cursor = null;
+    do {
+      const result = await this.request('model/list', {
+        cursor,
+        includeHidden: false,
+      });
+      models.push(...result.data);
+      cursor = result.nextCursor;
+    } while (cursor);
+    return models.map(({ id, model, displayName, description, isDefault }) => ({
+      id,
+      model,
+      displayName,
+      description,
+      isDefault,
+    }));
+  }
+
+  async generateMotion({ model, systemPrompt, prompt, refinePrompt, refine }) {
+    if (![model, systemPrompt, prompt].every((value) => typeof value === 'string' && value.trim())) {
+      throw new Error('Codex 生成リクエストが不正です。');
+    }
+    if (model.length > 100 || systemPrompt.length > 100_000 || prompt.length > 10_000) {
+      throw new Error('Codex 生成リクエストが長すぎます。');
+    }
+
+    await this.ensureServer();
+    const account = await this.request('account/read', { refreshToken: true });
+    if (account.account?.type !== 'chatgpt') {
+      throw new Error('Codex の認証が必要です。「ChatGPTでログイン」から認証してください。');
+    }
+
+    const started = await this.request('thread/start', {
+      model,
+      cwd: this.cwd,
+      baseInstructions: systemPrompt,
+      approvalPolicy: 'never',
+      sandbox: 'read-only',
+      ephemeral: true,
+    });
+    const threadId = started.thread.id;
+    let output = await this.runTurn(threadId, prompt, model);
+
+    if (refine && typeof refinePrompt === 'string' && refinePrompt.trim()) {
+      output = await this.runTurn(threadId, refinePrompt, model);
+    }
+
+    try {
+      return JSON.parse(output);
+    } catch {
+      throw new Error('Codex から有効なモーションJSONが返されませんでした。');
+    }
+  }
+
+  async runTurn(threadId, text, model) {
+    const completed = this.waitForTurn(threadId);
+    try {
+      await this.request('turn/start', {
+        threadId,
+        model,
+        effort: 'low',
+        input: [{ type: 'text', text }],
+        outputSchema: MOTION_OUTPUT_SCHEMA,
+      });
+      return await completed;
+    } catch (error) {
+      this.cancelTurnWait(threadId, error);
+      throw friendlyError(error);
+    }
+  }
+
+  waitForTurn(threadId) {
+    if (this.turns.has(threadId)) throw new Error('Codex のターンが既に実行中です。');
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.turns.delete(threadId);
+        reject(new Error('Codex の応答がタイムアウトしました。'));
+      }, TURN_TIMEOUT_MS);
+      this.turns.set(threadId, { messages: [], resolve, reject, timer });
+    });
+  }
+
+  cancelTurnWait(threadId, error) {
+    const turn = this.turns.get(threadId);
+    if (!turn) return;
+    clearTimeout(turn.timer);
+    this.turns.delete(threadId);
+    turn.reject(error);
+  }
+
+  async ensureServer() {
+    if (this.process) return;
+    if (this.starting) return this.starting;
+    this.starting = this.start();
+    try {
+      await this.starting;
+    } finally {
+      this.starting = null;
+    }
+  }
+
+  async start() {
+    this.version = await this.detectVersion();
+    if (compareVersions(this.version) < 0) {
+      throw new Error(`Codex CLI ${this.version} は古いため利用できません。0.144.1 以上へ更新してください。`);
+    }
+
+    await new Promise((resolve, reject) => {
+      const child = this.spawnProcess(this.command, ['app-server', '--stdio'], {
+        cwd: this.cwd,
+        env: process.env,
+        shell: process.platform === 'win32',
+        windowsHide: true,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      let settled = false;
+      child.once('spawn', () => {
+        settled = true;
+        this.process = child;
+        resolve();
+      });
+      child.once('error', (error) => {
+        if (!settled) reject(friendlyError(error));
+      });
+    });
+
+    const lines = readline.createInterface({ input: this.process.stdout });
+    lines.on('line', (line) => this.handleLine(line));
+    this.process.stderr.on('data', (chunk) => {
+      this.stderr = `${this.stderr}${chunk}`.slice(-4000);
+    });
+    this.process.once('exit', (code) => this.handleExit(code));
+
+    await this.request('initialize', {
+      clientInfo: { name: 'text-to-vrma', title: 'Text-To-VRMA', version: '1.0.0' },
+    });
+    this.notify('initialized', {});
+  }
+
+  detectVersion() {
+    return new Promise((resolve, reject) => {
+      this.exec(this.command, ['--version'], {
+        env: process.env,
+        shell: process.platform === 'win32',
+        windowsHide: true,
+        timeout: 10_000,
+      }, (error, stdout) => {
+        if (error) return reject(friendlyError(error));
+        const match = String(stdout).match(/(\d+\.\d+\.\d+)/);
+        if (!match) return reject(new Error('Codex CLI のバージョンを確認できませんでした。'));
+        resolve(match[1]);
+      });
+    });
+  }
+
+  request(method, params = {}) {
+    if (!this.process?.stdin?.writable) {
+      return Promise.reject(new Error('Codex app-server が起動していません。'));
+    }
+    const id = ++this.requestId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Codex (${method}) がタイムアウトしました。`));
+      }, REQUEST_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+      this.write({ method, id, params });
+    });
+  }
+
+  notify(method, params = {}) {
+    this.write({ method, params });
+  }
+
+  write(message) {
+    this.process.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  handleLine(line) {
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    if (message.id !== undefined) {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      this.pending.delete(message.id);
+      if (message.error) {
+        pending.reject(new Error(message.error.message || JSON.stringify(message.error)));
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+
+    const { method, params } = message;
+    if (method === 'item/completed' && params?.item?.type === 'agentMessage') {
+      this.turns.get(params.threadId)?.messages.push(params.item.text);
+    } else if (method === 'turn/completed') {
+      const turn = this.turns.get(params.threadId);
+      if (turn) {
+        clearTimeout(turn.timer);
+        this.turns.delete(params.threadId);
+        if (params.turn?.status === 'completed') {
+          turn.resolve(turn.messages.at(-1) || '');
+        } else {
+          turn.reject(new Error(params.turn?.error?.message || 'Codex の生成に失敗しました。'));
+        }
+      }
+    } else if (method === 'account/login/completed' || method === 'account/updated') {
+      this.emit('account-changed', { method, ...params });
+    }
+  }
+
+  handleExit(code) {
+    const detail = this.stderr.trim();
+    const error = new Error(
+      `Codex app-server が終了しました${code === null ? '' : ` (終了コード ${code})`}。` +
+      (detail ? `\n${detail}` : '')
+    );
+    this.process = null;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+    for (const threadId of this.turns.keys()) this.cancelTurnWait(threadId, error);
+    this.emit('server-exit', { error: error.message });
+  }
+
+  close() {
+    this.process?.kill();
+    this.process = null;
+  }
+}
+
+module.exports = {
+  CodexClient,
+  MIN_CODEX_VERSION,
+  MOTION_OUTPUT_SCHEMA,
+  compareVersions,
+  friendlyError,
+};

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,8 +1,9 @@
 // Electron メインプロセス — dist/ のビルド成果物を app:// スキームで配信する
 // APIキー等の秘密情報は一切埋め込まない (利用者が実行時に入力し、各自のPC内にのみ保存される)
-const { app, BrowserWindow, Menu, protocol, net, shell } = require('electron');
+const { app, BrowserWindow, Menu, protocol, net, shell, ipcMain, dialog } = require('electron');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
+const { CodexClient, friendlyError } = require('./codex-client.cjs');
 
 // file:// では fetch が使えないため、標準スキーム扱いの app:// で配信する
 protocol.registerSchemesAsPrivileged([
@@ -13,6 +14,51 @@ protocol.registerSchemesAsPrivileged([
 ]);
 
 const DIST_DIR = path.join(__dirname, '..', 'dist');
+let codexClient;
+
+function broadcastCodexStatus(status) {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send('codex:account-changed', status);
+  }
+}
+
+function registerCodexIpc() {
+  codexClient = new CodexClient({ cwd: app.getPath('temp') });
+  codexClient.on('account-changed', async () => {
+    broadcastCodexStatus(await codexClient.getStatus());
+  });
+  codexClient.on('server-exit', broadcastCodexStatus);
+
+  ipcMain.handle('codex:get-status', () => codexClient.getStatus());
+  ipcMain.handle('codex:list-models', () => codexClient.listModels());
+  ipcMain.handle('codex:generate-motion', async (_event, request) => {
+    try {
+      return await codexClient.generateMotion(request);
+    } catch (error) {
+      throw friendlyError(error);
+    }
+  });
+  ipcMain.handle('codex:login', async () => {
+    const result = await codexClient.login();
+    if (result.type !== 'chatgpt' || !result.authUrl) {
+      throw new Error('Codex からログインURLが返されませんでした。');
+    }
+    await shell.openExternal(result.authUrl);
+    return { loginId: result.loginId };
+  });
+  ipcMain.handle('codex:logout', async () => {
+    const { response } = await dialog.showMessageBox({
+      type: 'warning',
+      buttons: ['キャンセル', 'ログアウト'],
+      defaultId: 0,
+      cancelId: 0,
+      title: 'Codexからログアウト',
+      message: 'このPCのCodex CLI全体からログアウトします。続行しますか？',
+    });
+    if (response !== 1) return codexClient.getStatus();
+    return codexClient.logout();
+  });
+}
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -24,6 +70,7 @@ function createWindow() {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
+      preload: path.join(__dirname, 'preload.cjs'),
     },
   });
 
@@ -37,6 +84,7 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+  registerCodexIpc();
   protocol.handle('app', (request) => {
     const { pathname } = new URL(request.url);
     const rel = decodeURIComponent(pathname === '/' ? '/index.html' : pathname);
@@ -57,5 +105,6 @@ app.whenReady().then(() => {
 });
 
 app.on('window-all-closed', () => {
+  codexClient?.close();
   if (process.platform !== 'darwin') app.quit();
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,0 +1,14 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('codexBridge', {
+  getStatus: () => ipcRenderer.invoke('codex:get-status'),
+  login: () => ipcRenderer.invoke('codex:login'),
+  logout: () => ipcRenderer.invoke('codex:logout'),
+  listModels: () => ipcRenderer.invoke('codex:list-models'),
+  generateMotion: (request) => ipcRenderer.invoke('codex:generate-motion', request),
+  onAccountChanged: (listener) => {
+    const handler = (_event, status) => listener(status);
+    ipcRenderer.on('codex:account-changed', handler);
+    return () => ipcRenderer.removeListener('codex:account-changed', handler);
+  },
+});

--- a/index.html
+++ b/index.html
@@ -101,6 +101,16 @@
     #viewerWrap { flex: 1; position: relative; }
     canvas { display: block; width: 100%; height: 100%; }
     .section-title { font-size: 12px; color: var(--muted); font-weight: 600; margin-top: 2px; }
+    .auth-box { display: flex; flex-direction: column; gap: 8px; }
+    .auth-state {
+      font-size: 11.5px; line-height: 1.5; color: var(--muted);
+      border-left: 2px solid var(--border); padding-left: 8px;
+    }
+    .auth-state.ok { color: var(--accent); border-color: var(--accent); }
+    .auth-state.err { color: #ff8484; border-color: #ff8484; }
+    .auth-actions { display: flex; gap: 8px; }
+    .auth-actions button { flex: 1; padding: 8px; font-size: 12px; }
+    .hidden { display: none !important; }
   </style>
 </head>
 <body>
@@ -113,13 +123,29 @@
     <input type="file" id="vrmFile" accept=".vrm" style="display:none" />
     <p class="sub" id="vrmName">読み込み中... — 3Dビューへのドラッグ&amp;ドロップでも読み込めます。</p>
 
-    <div class="section-title">2. 🤖 OpenAI API 設定</div>
-    <input type="password" id="apiKey" placeholder="OpenAI APIキー (sk-...)" />
-    <select id="modelSelect">
-      <option value="gpt-5.6-sol">gpt-5.6-sol (最高精度)</option>
-      <option value="gpt-5.6-terra">gpt-5.6-terra (バランス)</option>
-      <option value="gpt-5.6-luna">gpt-5.6-luna (低コスト)</option>
+    <div class="section-title">2. 🤖 OpenAI 認証・モデル</div>
+    <select id="authMode">
+      <option value="api-key">OpenAI APIキー</option>
+      <option value="codex">Codexサブスクリプション</option>
     </select>
+    <div id="apiSettings" class="auth-box">
+      <input type="password" id="apiKey" placeholder="OpenAI APIキー (sk-...)" />
+      <select id="apiModelSelect">
+        <option value="gpt-5.6-sol">gpt-5.6-sol (最高精度)</option>
+        <option value="gpt-5.6-terra">gpt-5.6-terra (バランス)</option>
+        <option value="gpt-5.6-luna">gpt-5.6-luna (低コスト)</option>
+      </select>
+    </div>
+    <div id="codexSettings" class="auth-box hidden">
+      <div id="codexAuthState" class="auth-state">Codex CLIを確認中...</div>
+      <select id="codexModelSelect" disabled>
+        <option value="">ログイン後にモデルを取得します</option>
+      </select>
+      <div class="auth-actions">
+        <button id="codexLoginBtn" class="primary-outline">ChatGPTでログイン</button>
+        <button id="codexLogoutBtn" disabled>ログアウト</button>
+      </div>
+    </div>
     <label class="check" title="生成後にもう1パス、可動域・軌道・緩急のセルフレビューを行って品質を上げます。時間とAPIコストは約2倍になります。">
       <input type="checkbox" id="refineCheck" checked />
       🔍 自己修正 (2パス生成で品質向上)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "node --test test/*.test.cjs",
     "preview": "vite preview",
     "app:dev": "electron .",
     "app:build": "vite build && electron-builder --win portable"

--- a/src/llm.js
+++ b/src/llm.js
@@ -320,6 +320,44 @@ export async function generateMotionWithOpenAI(
   return spec;
 }
 
+/**
+ * Electron の Codex CLI (ChatGPT/Codex サブスクリプション) でモーション spec を生成する。
+ * 認証情報は preload の限定 IPC 内に留まり、レンダラーには渡されない。
+ */
+export async function generateMotionWithCodex(
+  text,
+  model,
+  { refine = true, onProgress } = {}
+) {
+  if (!window.codexBridge) {
+    throw new Error('Codex認証はデスクトップ版でのみ利用できます。');
+  }
+
+  const flavor = randomFlavor();
+  const userMsg =
+    `次の動きのモーションを作成: ${text}\n` +
+    `(今回の演出の味付け: ${flavor}。ただしユーザーの指示と矛盾する場合は指示を優先)`;
+
+  onProgress?.(
+    refine
+      ? `Codex (${model}) がモーションを生成・自己修正中...`
+      : `Codex (${model}) がモーションを生成中...`
+  );
+  const spec = await window.codexBridge.generateMotion({
+    model,
+    systemPrompt: SYSTEM_PROMPT,
+    prompt: userMsg,
+    refinePrompt: REFINE_INSTRUCTION,
+    refine,
+  });
+
+  validateSpec(spec);
+  if (!spec.hips?.length) delete spec.hips;
+  if (WAVE_RE.test(text)) applyWaveCorrection(spec);
+  spec.flavor = flavor;
+  return spec;
+}
+
 const MAX_DURATION = 20; // 秒
 
 // 毎回ランダムに混ぜる「演出の味付け」— 同じ指示でも違う振り付けを引き出す

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,11 @@
 import { Viewer } from './viewer.js';
 import { buildVRMA } from './vrmaBuilder.js';
 import { idleSpec } from './idleMotion.js';
-import { generateMotionWithOpenAI, DEFAULT_OPENAI_MODEL } from './llm.js';
+import {
+  generateMotionWithOpenAI,
+  generateMotionWithCodex,
+  DEFAULT_OPENAI_MODEL,
+} from './llm.js';
 
 const $ = (id) => document.getElementById(id);
 const statusEl = $('status');
@@ -11,7 +15,14 @@ const generateBtn = $('generateBtn');
 const exportBtn = $('exportBtn');
 const exprCheck = $('exprCheck');
 const apiKeyInput = $('apiKey');
-const modelSelect = $('modelSelect');
+const authModeSelect = $('authMode');
+const apiSettings = $('apiSettings');
+const codexSettings = $('codexSettings');
+const apiModelSelect = $('apiModelSelect');
+const codexModelSelect = $('codexModelSelect');
+const codexAuthState = $('codexAuthState');
+const codexLoginBtn = $('codexLoginBtn');
+const codexLogoutBtn = $('codexLogoutBtn');
 const refineCheck = $('refineCheck');
 const vrmBtn = $('vrmBtn');
 const vrmFile = $('vrmFile');
@@ -22,6 +33,78 @@ const historyEl = $('history');
 let lastVRMA = null; // { spec, name }
 const history = []; // [{ name, spec, buffer, loop, duration, text }]
 const MAX_HISTORY = 20;
+const codexBridge = window.codexBridge;
+let codexStatus = null;
+
+function setCodexAuthState(message, kind = '') {
+  codexAuthState.textContent = message;
+  codexAuthState.className = `auth-state${kind ? ` ${kind}` : ''}`;
+}
+
+function renderAuthMode() {
+  const codexMode = authModeSelect.value === 'codex' && Boolean(codexBridge);
+  apiSettings.classList.toggle('hidden', codexMode);
+  codexSettings.classList.toggle('hidden', !codexMode);
+}
+
+async function loadCodexModels() {
+  const models = await codexBridge.listModels();
+  codexModelSelect.replaceChildren();
+  for (const model of models) {
+    const option = document.createElement('option');
+    option.value = model.model;
+    option.textContent = `${model.displayName}${model.isDefault ? ' (推奨)' : ''}`;
+    option.title = model.description;
+    codexModelSelect.appendChild(option);
+  }
+  const saved = localStorage.getItem('codex-model');
+  const savedOption = [...codexModelSelect.options].find((option) => option.value === saved);
+  const defaultModel = models.find((model) => model.isDefault)?.model;
+  codexModelSelect.value = savedOption?.value || defaultModel || models[0]?.model || '';
+  codexModelSelect.disabled = models.length === 0;
+}
+
+async function refreshCodexStatus(providedStatus) {
+  if (!codexBridge) return;
+  try {
+    codexStatus = providedStatus || await codexBridge.getStatus();
+    const account = codexStatus.account;
+    if (!codexStatus.available) {
+      setCodexAuthState(codexStatus.error || 'Codex CLIを利用できません。', 'err');
+    } else if (account?.type === 'chatgpt') {
+      const identity = account.email || 'ChatGPTアカウント';
+      setCodexAuthState(
+        `ログイン済み: ${identity}\nプラン: ${account.planType} / CLI: ${codexStatus.version}`,
+        'ok'
+      );
+      await loadCodexModels();
+    } else {
+      setCodexAuthState(`未ログイン / Codex CLI ${codexStatus.version}`);
+      codexModelSelect.disabled = true;
+    }
+    codexLoginBtn.disabled = !codexStatus.available || account?.type === 'chatgpt';
+    codexLogoutBtn.disabled = account?.type !== 'chatgpt';
+  } catch (error) {
+    codexStatus = { available: false, account: null };
+    setCodexAuthState(error.message, 'err');
+    codexLoginBtn.disabled = true;
+    codexLogoutBtn.disabled = true;
+  }
+}
+
+async function initializeAuth() {
+  if (!codexBridge) {
+    authModeSelect.querySelector('option[value="codex"]')?.remove();
+    authModeSelect.value = 'api-key';
+    renderAuthMode();
+    return;
+  }
+  authModeSelect.value = localStorage.getItem('openai-auth-mode') === 'codex'
+    ? 'codex'
+    : 'api-key';
+  renderAuthMode();
+  await refreshCodexStatus();
+}
 
 // エクスポート用 VRMA を生成する (表情の有無はチェックボックスで選択)
 function buildExportVRMA(spec) {
@@ -176,9 +259,14 @@ generateBtn.addEventListener('click', async () => {
     setStatus('テキストを入力してください。', 'err');
     return;
   }
+  const authMode = authModeSelect.value;
   const apiKey = apiKeyInput.value.trim();
-  if (!apiKey) {
+  if (authMode === 'api-key' && !apiKey) {
     setStatus('OpenAI APIキーを入力してください。', 'err');
+    return;
+  }
+  if (authMode === 'codex' && codexStatus?.account?.type !== 'chatgpt') {
+    setStatus('先に「ChatGPTでログイン」からCodexを認証してください。', 'err');
     return;
   }
   if (!viewer.vrm) {
@@ -187,15 +275,24 @@ generateBtn.addEventListener('click', async () => {
   }
   generateBtn.disabled = true;
   try {
-    localStorage.setItem('openai-api-key', apiKey);
-    const model = modelSelect.value;
-    localStorage.setItem('openai-model', model);
+    const model = authMode === 'codex' ? codexModelSelect.value : apiModelSelect.value;
+    if (!model) throw new Error('利用可能なモデルがありません。');
+    localStorage.setItem('openai-auth-mode', authMode);
+    if (authMode === 'api-key') {
+      localStorage.setItem('openai-api-key', apiKey);
+      localStorage.setItem('openai-model', model);
+    } else {
+      localStorage.setItem('codex-model', model);
+    }
     localStorage.setItem('refine-enabled', refineCheck.checked ? '1' : '0');
-    setStatus(`OpenAI (${model}) がモーションを生成中... (数十秒かかることがあります)`);
-    const spec = await generateMotionWithOpenAI(text, apiKey, model, {
+    setStatus(`${authMode === 'codex' ? 'Codex' : 'OpenAI'} (${model}) がモーションを生成中...`);
+    const options = {
       refine: refineCheck.checked,
       onProgress: (msg) => setStatus(msg),
-    });
+    };
+    const spec = authMode === 'codex'
+      ? await generateMotionWithCodex(text, model, options)
+      : await generateMotionWithOpenAI(text, apiKey, model, options);
     window.__lastSpec = spec; // 診断用
     console.log('[Text-To-VRMA] generated spec:', spec);
     const buffer = await playSpec(spec);
@@ -273,13 +370,41 @@ apiKeyInput.value = localStorage.getItem('openai-api-key') ?? '';
 refineCheck.checked = localStorage.getItem('refine-enabled') !== '0';
 exprCheck.checked = localStorage.getItem('export-expressions') !== '0';
 const savedModel = localStorage.getItem('openai-model');
-if (savedModel && [...modelSelect.options].some((o) => o.value === savedModel)) {
-  modelSelect.value = savedModel;
+if (savedModel && [...apiModelSelect.options].some((o) => o.value === savedModel)) {
+  apiModelSelect.value = savedModel;
 } else {
-  modelSelect.value = DEFAULT_OPENAI_MODEL;
+  apiModelSelect.value = DEFAULT_OPENAI_MODEL;
 }
+authModeSelect.addEventListener('change', () => {
+  localStorage.setItem('openai-auth-mode', authModeSelect.value);
+  renderAuthMode();
+  if (authModeSelect.value === 'codex') refreshCodexStatus();
+});
+codexModelSelect.addEventListener('change', () => {
+  localStorage.setItem('codex-model', codexModelSelect.value);
+});
+codexLoginBtn.addEventListener('click', async () => {
+  codexLoginBtn.disabled = true;
+  try {
+    await codexBridge.login();
+    setCodexAuthState('ブラウザでChatGPTへのログインを完了してください...');
+  } catch (error) {
+    setCodexAuthState(error.message, 'err');
+    await refreshCodexStatus();
+  }
+});
+codexLogoutBtn.addEventListener('click', async () => {
+  codexLogoutBtn.disabled = true;
+  try {
+    await refreshCodexStatus(await codexBridge.logout());
+  } catch (error) {
+    setCodexAuthState(error.message, 'err');
+  }
+});
+codexBridge?.onAccountChanged((status) => refreshCodexStatus(status));
 textInput.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) generateBtn.click();
 });
 
+initializeAuth();
 init();

--- a/test/codex-client.test.cjs
+++ b/test/codex-client.test.cjs
@@ -1,0 +1,186 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const { PassThrough } = require('node:stream');
+const {
+  CodexClient,
+  MOTION_OUTPUT_SCHEMA,
+  compareVersions,
+  friendlyError,
+} = require('../electron/codex-client.cjs');
+
+function createFakeCodex({ version = '0.144.4' } = {}) {
+  const child = new EventEmitter();
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = () => child.emit('exit', 0);
+  let turnCount = 0;
+  let threadStartParams;
+
+  child.stdin.on('data', (chunk) => {
+    for (const line of String(chunk).trim().split('\n')) {
+      if (!line) continue;
+      const request = JSON.parse(line);
+      if (request.id === undefined) continue;
+      let result;
+      if (request.method === 'initialize') {
+        result = { userAgent: 'fake-codex' };
+      } else if (request.method === 'account/read') {
+        result = {
+          account: { type: 'chatgpt', email: 'test@example.com', planType: 'plus' },
+          requiresOpenaiAuth: true,
+        };
+      } else if (request.method === 'model/list') {
+        result = {
+          data: [{
+            id: 'gpt-test', model: 'gpt-test', displayName: 'GPT Test',
+            description: 'Test model', isDefault: true,
+          }],
+          nextCursor: null,
+        };
+      } else if (request.method === 'thread/start') {
+        threadStartParams = request.params;
+        result = { thread: { id: 'thread-1' } };
+      } else if (request.method === 'turn/start') {
+        turnCount += 1;
+        result = { turn: { id: `turn-${turnCount}` } };
+        const spec = {
+          name: turnCount === 1 ? 'draft' : 'refined',
+          duration: 2,
+          loop: false,
+          tracks: { head: [{ t: 0, r: [0, 0, 0] }] },
+        };
+        process.nextTick(() => {
+          child.stdout.write(`${JSON.stringify({
+            method: 'item/completed',
+            params: {
+              threadId: 'thread-1', turnId: `turn-${turnCount}`,
+              item: { type: 'agentMessage', text: JSON.stringify(spec) },
+            },
+          })}\n`);
+          child.stdout.write(`${JSON.stringify({
+            method: 'turn/completed',
+            params: {
+              threadId: 'thread-1',
+              turn: { id: `turn-${turnCount}`, status: 'completed' },
+            },
+          })}\n`);
+        });
+      } else if (request.method === 'account/login/start') {
+        result = { type: 'chatgpt', authUrl: 'https://example.com/login', loginId: 'login-1' };
+      } else if (request.method === 'account/logout') {
+        result = {};
+      } else {
+        throw new Error(`Unhandled fake method: ${request.method}`);
+      }
+      child.stdout.write(`${JSON.stringify({ id: request.id, result })}\n`);
+    }
+  });
+
+  const client = new CodexClient({
+    cwd: '/tmp',
+    spawnProcess: () => {
+      process.nextTick(() => child.emit('spawn'));
+      return child;
+    },
+    exec: (_command, _args, _options, callback) => {
+      process.nextTick(() => callback(null, `codex-cli ${version}\n`, ''));
+    },
+  });
+
+  return {
+    client,
+    child,
+    getTurnCount: () => turnCount,
+    getThreadStartParams: () => threadStartParams,
+  };
+}
+
+test('バージョンを最低要件と比較する', () => {
+  assert.equal(compareVersions('0.144.1'), 0);
+  assert.ok(compareVersions('0.145.0') > 0);
+  assert.ok(compareVersions('0.143.9') < 0);
+});
+
+test('Codex出力スキーマはルートの全プロパティを必須にする', () => {
+  assert.deepEqual(
+    [...MOTION_OUTPUT_SCHEMA.required].sort(),
+    Object.keys(MOTION_OUTPUT_SCHEMA.properties).sort()
+  );
+});
+
+test('Codex出力スキーマの全objectは固定キーをすべて必須にする', () => {
+  function assertStrictObjects(schema, path = 'root') {
+    if (schema.type === 'object') {
+      assert.equal(schema.additionalProperties, false, `${path} must reject unknown keys`);
+      assert.deepEqual(
+        [...schema.required].sort(),
+        Object.keys(schema.properties).sort(),
+        `${path} must require every property`
+      );
+      for (const [name, child] of Object.entries(schema.properties)) {
+        assertStrictObjects(child, `${path}.${name}`);
+      }
+    }
+    if (schema.type === 'array') assertStrictObjects(schema.items, `${path}[]`);
+  }
+
+  assertStrictObjects(MOTION_OUTPUT_SCHEMA);
+});
+
+test('Codexの認証状態とモデル一覧を取得する', async () => {
+  const { client } = createFakeCodex();
+  const status = await client.getStatus();
+  assert.equal(status.available, true);
+  assert.equal(status.account.email, 'test@example.com');
+  assert.equal(status.version, '0.144.4');
+
+  const models = await client.listModels();
+  assert.deepEqual(models, [{
+    id: 'gpt-test', model: 'gpt-test', displayName: 'GPT Test',
+    description: 'Test model', isDefault: true,
+  }]);
+  client.close();
+});
+
+test('同じ一時スレッドで生成と自己修正を実行する', async () => {
+  const { client, getTurnCount, getThreadStartParams } = createFakeCodex();
+  const result = await client.generateMotion({
+    model: 'gpt-test',
+    systemPrompt: 'モーションJSONを生成してください。',
+    prompt: '手を振る',
+    refinePrompt: '結果を自己修正してください。',
+    refine: true,
+  });
+  assert.equal(result.name, 'refined');
+  assert.equal(getTurnCount(), 2);
+  assert.equal('dynamicTools' in getThreadStartParams(), false);
+  client.close();
+});
+
+test('自己修正が無効なら1ターンだけ実行する', async () => {
+  const { client, getTurnCount } = createFakeCodex();
+  const result = await client.generateMotion({
+    model: 'gpt-test',
+    systemPrompt: 'モーションJSONを生成してください。',
+    prompt: 'うなずく',
+    refine: false,
+  });
+  assert.equal(result.name, 'draft');
+  assert.equal(getTurnCount(), 1);
+  client.close();
+});
+
+test('古いCLIは利用不可として返す', async () => {
+  const { client } = createFakeCodex({ version: '0.143.0' });
+  const status = await client.getStatus();
+  assert.equal(status.available, false);
+  assert.match(status.error, /0\.144\.1 以上/);
+});
+
+test('CLI未導入エラーを利用者向けに変換する', () => {
+  const error = new Error('spawn codex ENOENT');
+  error.code = 'ENOENT';
+  assert.match(friendlyError(error).message, /Codex CLI が見つかりません/);
+});


### PR DESCRIPTION
こんにちは。API_KEYだけだと使うほど金銭的負担が大きくなる懸念があるので、CodexユーザーはCodexのサブスクリプションでも使えるようにしました。
マージしていただいても、内容を参考いただくだけでクローズでもどちらでも構いません。ご検討よろしくお願いします。

  ## 概要

  Electronデスクトップ版で、OpenAI APIキーに加えてCodexサブスクリプションを利用したモーション生成に対応しました。

  Codex CLIの既存ログイン情報を利用できるほか、アプリからChatGPTへのログイン、モデル選択、ログアウトを行えます。ブラウザ版では従来どおりAPIキー方式のみ利用できます。

  ## 主な変更

  - Codex CLIのapp-serverと通信するクライアントを追加
    - Codex CLIの存在とバージョンを確認
    - ChatGPTアカウントの認証状態を取得
    - ログイン・ログアウト処理
    - 利用可能なモデル一覧を取得
    - Structured Outputsを使ったモーション生成
  - 同じ一時スレッド内で、モーション生成と自己修正を実行
  - Electronのpreload/IPC経由でCodex機能をレンダラーへ公開
    - Codexの認証情報やトークンはレンダラーやlocalStorageへ渡さない構成
  - 認証方式を選択できるUIを追加
    - OpenAI APIキー
    - Codexサブスクリプション
  - Codexのログイン状態、プラン、CLIバージョンを画面に表示
  - Codexのモデル選択を追加し、選択内容をlocalStorageへ保存
  - CLI未導入、バージョン不足、認証エラー、利用上限などのエラー表示を改善
  - Codex利用方法と注意事項をREADMEへ追記
  - Codexクライアントのユニットテストを追加

  ## 利用条件・注意事項

  - Codexサブスクリプション認証はElectronデスクトップ版専用です
  - PATH上にCodex CLI 0.144.1以上が必要です
  - Codex CLIはアプリには同梱されません
  - Codexモードの利用量は、ログイン中のChatGPT/Codexプランおよび組織ポリシーに従います
  - アプリからログアウトすると、このPC上のCodex CLI全体がログアウトされます
  - ブラウザ版では引き続きOpenAI APIキーを使用します

  ## 動作確認

  - [x] `npm test`
    - 8件すべて成功
  - [x] `npm run build`
    - Viteのプロダクションビルド成功
  - [x] 実際のChatGPTアカウントを使用したログイン・生成フローの手動確認