### PR TITLE
Fix engine switching and Codex authentication UI in Electron

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,8 @@
     .pill { padding: 8px 12px; border-radius: 8px; font-size: 12px; font-weight: 600; white-space: nowrap; }
     .pill.ok { background: rgba(52,209,122,0.14); color: var(--accent); border: 1px solid rgba(52,209,122,0.4); }
     .auth-box { display: flex; flex-direction: column; gap: 9px; }
+    /* API設定をARDY用スロットへ移動したとき、空の復帰先はカード内の余白を作らない */
+    #apiSettingsHome:empty { display: none; }
     .auth-state { font-size: 11.5px; line-height: 1.5; color: var(--muted); }
     .auth-state.ok { color: var(--accent); }
     .auth-state.err { color: #ff8484; }
@@ -282,21 +284,23 @@
             <option value="ardy" data-i18n="engine.ardy">ARDYローカルエンジン</option>
           </select>
         </div>
-        <div id="apiSettings" class="auth-box">
-          <input type="password" id="apiKey" placeholder="OpenAI APIキー (sk-...)" data-i18n-placeholder="apiKey.ph" />
-          <select id="apiModelSelect">
-            <option value="gpt-5.6-sol" data-i18n="model.best">gpt-5.6-sol (最高精度)</option>
-            <option value="gpt-5.6-terra" data-i18n="model.balanced">gpt-5.6-terra (バランス)</option>
-            <option value="gpt-5.6-luna" data-i18n="model.low">gpt-5.6-luna (低コスト)</option>
-          </select>
-          <details class="ardy-fold">
-            <summary data-i18n="api.customHead">🔌 OpenAI互換プロバイダを使う (任意)</summary>
-            <p class="sub" style="margin:6px 0" data-i18n="api.customNote">OpenRouter / DeepSeek / Ollama 等のOpenAI互換APIを使う場合に設定します。空欄なら公式OpenAIを使います。</p>
-            <label class="field-label" data-i18n="api.baseUrl">APIベースURL</label>
-            <input type="text" id="apiBaseUrl" placeholder="https://api.openai.com/v1" />
-            <label class="field-label" style="margin-top:6px" data-i18n="api.customModel">モデル名 (カスタム)</label>
-            <input type="text" id="apiCustomModel" placeholder="例: deepseek-chat / meta-llama/llama-3.1-8b-instruct" data-i18n-placeholder="api.customModelPh" />
-          </details>
+        <div id="apiSettingsHome">
+          <div id="apiSettings" class="auth-box">
+            <input type="password" id="apiKey" placeholder="OpenAI APIキー (sk-...)" data-i18n-placeholder="apiKey.ph" />
+            <select id="apiModelSelect">
+              <option value="gpt-5.6-sol" data-i18n="model.best">gpt-5.6-sol (最高精度)</option>
+              <option value="gpt-5.6-terra" data-i18n="model.balanced">gpt-5.6-terra (バランス)</option>
+              <option value="gpt-5.6-luna" data-i18n="model.low">gpt-5.6-luna (低コスト)</option>
+            </select>
+            <details class="ardy-fold">
+              <summary data-i18n="api.customHead">🔌 OpenAI互換プロバイダを使う (任意)</summary>
+              <p class="sub" style="margin:6px 0" data-i18n="api.customNote">OpenRouter / DeepSeek / Ollama 等のOpenAI互換APIを使う場合に設定します。空欄なら公式OpenAIを使います。</p>
+              <label class="field-label" data-i18n="api.baseUrl">APIベースURL</label>
+              <input type="text" id="apiBaseUrl" placeholder="https://api.openai.com/v1" />
+              <label class="field-label" style="margin-top:6px" data-i18n="api.customModel">モデル名 (カスタム)</label>
+              <input type="text" id="apiCustomModel" placeholder="例: deepseek-chat / meta-llama/llama-3.1-8b-instruct" data-i18n-placeholder="api.customModelPh" />
+            </details>
+          </div>
         </div>
         <div id="codexSettings" class="auth-box hidden">
           <div id="codexAuthState" class="auth-state" data-i18n="codex.checking">Codex CLIを確認中...</div>

--- a/src/main.js
+++ b/src/main.js
@@ -140,16 +140,18 @@ function maskEmail(email) {
   return `${user.slice(0, 2)}***@${domain}`;
 }
 
-const panelEl = $('panel');
+const apiSettingsHome = $('apiSettingsHome');
 const ardyGptSlot = $('ardyGptSlot');
 function renderAuthMode() {
   const mode = authModeSelect.value;
   const codexMode = mode === 'codex' && Boolean(codexBridge);
   const ardyMode = mode === 'ardy';
   // OpenAIキー+モデル選択は、api-keyモード(エンジン本体)でもARDYモード(任意の頭脳)でも使う。
-  // ARDYモードでは同じ要素をARDYパネル内の「GPT (頭)」欄へ移動して見せる
-  if (ardyMode) ardyGptSlot.appendChild(apiSettings);
-  else panelEl.insertBefore(apiSettings, codexSettings);
+  // ARDYモードでは同じ要素をARDYパネル内の「GPT (頭)」欄へ移動して見せる。
+  // 復帰先は専用スロットに固定する。以前の #panel.insertBefore() は、#panel の
+  // 子ではない codexSettings を referenceNode にしており NotFoundError になっていた。
+  const apiSettingsSlot = ardyMode ? ardyGptSlot : apiSettingsHome;
+  if (apiSettings.parentElement !== apiSettingsSlot) apiSettingsSlot.append(apiSettings);
   apiSettings.classList.toggle('hidden', codexMode);
   codexSettings.classList.toggle('hidden', !codexMode);
   ardySettings.classList.toggle('hidden', !ardyMode);
@@ -157,19 +159,40 @@ function renderAuthMode() {
   $('waypointRow').classList.toggle('hidden', !ardyMode);
   refineCheck.parentElement.classList.toggle('hidden', ardyMode); // 自己修正はLLMキーフレーム専用
   if (ardyMode) checkArdyHealth();
+  else cancelArdyHealthCheck();
 }
 
 // --- ARDYローカルエンジン ---
+let ardyHealthController = null;
+
+function isArdyMode() {
+  return authModeSelect.value === 'ardy';
+}
+
+function cancelArdyHealthCheck() {
+  ardyHealthController?.abort();
+  ardyHealthController = null;
+}
+
 function setArdyState(message, kind = '') {
   ardyState.textContent = message;
   ardyState.className = `auth-state${kind ? ` ${kind}` : ''}`;
 }
 
 async function checkArdyHealth({ showFailure = true } = {}) {
+  // ARDYを選択していない間は接続しない。切り替え直後に古い非同期応答が
+  // 非表示のARDYパネルを書き換えることも防ぐ。
+  if (!isArdyMode()) return false;
+  cancelArdyHealthCheck();
+  const controller = new AbortController();
+  ardyHealthController = controller;
   const url = ardyUrlInput.value.trim().replace(/\/$/, '');
   try {
-    const res = await fetch(`${url}/health`, { signal: AbortSignal.timeout(3000) });
+    const res = await fetch(`${url}/health`, {
+      signal: AbortSignal.any([controller.signal, AbortSignal.timeout(3000)]),
+    });
     const info = await res.json();
+    if (controller.signal.aborted || !isArdyMode()) return false;
     if (info.status === 'loading') {
       // モデル読み込み中: サーバーが返す実進捗%を表示する
       setArdyState(t('ardy.booting', { pct: Math.round((info.progress || 0) * 100) }), 'ok');
@@ -188,12 +211,14 @@ async function checkArdyHealth({ showFailure = true } = {}) {
     ardySetupBtn.classList.add('hidden');
     return true;
   } catch {
+    if (controller.signal.aborted || !isArdyMode()) return false;
     // 起動待ちのポーリング中は、モデル初期化中の接続失敗で
     // 「未起動」表示や起動ボタンを一時的に復活させない。
     if (!showFailure) return false;
     if (window.ardyBridge) {
       // 未セットアップならボタンを「セットアップ」に切り替える (JSONを触らせない)
       const st = await window.ardyBridge.getStatus().catch(() => null);
+      if (controller.signal.aborted || !isArdyMode()) return false;
       const configured = Boolean(st?.configured);
       ardyStartBtn.textContent = t('btn.engineStart');
       ardyStartBtn.dataset.mode = configured ? 'start' : 'setup';
@@ -211,6 +236,8 @@ async function checkArdyHealth({ showFailure = true } = {}) {
       ardySetupBtn.classList.add('hidden');
     }
     return false;
+  } finally {
+    if (ardyHealthController === controller) ardyHealthController = null;
   }
 }
 
@@ -1069,7 +1096,9 @@ if (savedModel && [...apiModelSelect.options].some((o) => o.value === savedModel
 } else {
   apiModelSelect.value = DEFAULT_OPENAI_MODEL;
 }
-ardyUrlInput.addEventListener('change', () => checkArdyHealth());
+ardyUrlInput.addEventListener('change', () => {
+  if (isArdyMode()) checkArdyHealth();
+});
 
 // --- 経由地モード: 床クリックで配置 ---
 // カメラ回転のドラッグと区別するため、押した位置から動いていないクリックだけ拾う


### PR DESCRIPTION
<img width="1582" height="960" alt="Before" src="https://github.com/user-attachments/assets/6e757afc-afdb-4ccd-b4b3-0884527b5e9a" />

## 概要

生成エンジン切り替え時に、前のエンジン用UIが残る不具合を修正しました。

例えば、ARDYローカルエンジンを選択した後に Codex サブスクリプションや OpenAI API へ切り替えても、ARDY用UIが残り、Codex の認証UI（「ChatGPTでログイン」）が表示されない状態になっていました。

原因は、`apiSettings` の復帰時に、親子関係にない `#panel` と `#codexSettings` を使って `insertBefore()` を呼び出していたため、`NotFoundError` が発生し、UI更新処理が途中で中断されていたことです。

## 変更内容

- API設定の復帰先を `apiSettingsHome` スロットとして固定
- `insertBefore()` を使わず、API / Codex / ARDY の各モードで安定してDOMを移動
- ARDYのヘルスチェックをARDY選択中だけに限定
- エンジン切り替え時に進行中のARDYヘルスチェックを中断し、古い非同期応答がUIを更新しないように修正

## 動作確認環境

- macOS (Apple Silicon)
- Electron (`npm run app:dev`)

## 確認

- `npm test`：成功（8件）
- `npm run build`：成功
- `npm run app:dev`：起動確認済み
- 初期表示および API → Codex → ARDY を含む複数回の往復切り替えを確認
- `insertBefore` の `NotFoundError` が発生しないことを確認
- Codexサブスクリプション選択時に「ChatGPTでログイン」UIが正しく表示されることを確認
- ARDY未起動時の接続エラーは、ARDY選択中のみ発生することを確認

---

## Summary

Fixed an issue where switching the generation engine could leave the previous engine's UI visible.

For example, after selecting the ARDY local engine, switching back to Codex Subscription or OpenAI API left the ARDY-specific UI visible and prevented the Codex authentication UI ("Sign in with ChatGPT") from appearing.

The root cause was an invalid `insertBefore()` call. During restoration of `apiSettings`, `#codexSettings` was used as the reference node for `#panel`, even though it was no longer a child of `#panel`, causing a `NotFoundError` and aborting the UI update.

## Changes

- Added a stable `apiSettingsHome` slot for restoring API settings.
- Replaced the fragile `insertBefore()` flow with stable DOM placement for API, Codex, and ARDY modes.
- Limited ARDY health checks to when the ARDY engine is selected.
- Cancel in-flight ARDY health checks when switching engines, preventing stale async responses from updating the UI.

## Tested on

- macOS (Apple Silicon)
- Electron (`npm run app:dev`)

## Verification

- `npm test`: passed (8 tests)
- `npm run build`: passed
- `npm run app:dev`: launched successfully
- Verified initial rendering and repeated switching between API, Codex, and ARDY.
- Confirmed that the Codex authentication UI ("Sign in with ChatGPT") is displayed correctly.
- Confirmed that no `insertBefore` `NotFoundError` occurs.
- Confirmed that ARDY connection errors only occur while the ARDY engine is selected.

Thanks for maintaining this project!